### PR TITLE
Packaging Scripts Added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ node_modules
 .gitsync_lock
 .codesync_lock
 
+.DS_Store
+/release-builds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "themebuilder",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "clone-bootstrap": "node ./lib/tasks/git_clone_bootstrap.js",
     "init-custom": "node ./lib/tasks/init_custom_scss.js",
     "test": "mocha --no-colors",
-    "test-watch": "mocha --watch --no-colors"
+    "test-watch": "mocha --watch --no-colors",
+    "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64  --prune=true --out=release-builds",
+    "package-win": "electron-packager . themebuilder --overwrite --asar=true --platform=win32 --arch=ia32 --prune=true --out=release-builds --version-string.CompanyName=CE --version-string.FileDescription=CE --version-string.ProductName=\"Theme Builder\"",
+    "package-linux": "electron-packager . themebuilder --overwrite --asar=true --platform=linux --arch=x64 --prune=true --out=release-builds"
   },
   "keywords": [
     "desktop",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themebuilder",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Bootstrap theme builder.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I added a few packaging scripts to `package.json`. With these scripts, you can package the source code into an application file (`.app`, `.exe`, etc). I also built the latest version into `.app` and added it to a new release (1.0.2); however, you can just use the `package-win` script if you're on a Windows machine.

One more thing - I gave your `.gitignore` a few additions to accommodate Macs and the packaging scripts.